### PR TITLE
feat(tabpanel): add tabpanel component

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,6 +1,11 @@
-import React, { FC } from "react";
+import React from "react";
 import { MemoryRouter } from "react-router-dom";
 import { Preview } from "@storybook/react";
+
+const initialRoute = {
+  pathname: "/",
+  state: { rrtId: "abc123" },
+};
 
 const preview: Preview = {
   parameters: {
@@ -14,7 +19,7 @@ const preview: Preview = {
   },
   decorators: [
     (Story) => (
-      <MemoryRouter initialEntries={["/"]}>
+      <MemoryRouter initialEntries={[initialRoute]}>
         <Story />
       </MemoryRouter>
     ),

--- a/src/components/Tabpanel/Tabpanel.test.tsx
+++ b/src/components/Tabpanel/Tabpanel.test.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { Tabpanel } from "./Tabpanel";
+import { RouterProvider, createMemoryRouter } from "react-router-dom";
+import { RoutingTabs } from "../../context";
+import { enableFetchMocks } from "jest-fetch-mock";
+import { TabPanelWindow } from "../TabPanelWindow";
+
+enableFetchMocks();
+
+const TestComponent = () => (
+  <RoutingTabs>
+    <TabPanelWindow isOutlet>
+      <Tabpanel>
+        <h1>Test Tabpanel</h1>
+        <p>Howdy!</p>
+        <p>This is for testing purposes</p>
+      </Tabpanel>
+    </TabPanelWindow>
+  </RoutingTabs>
+);
+
+const initialEntries = [
+  {
+    pathname: "/",
+    state: { rrtId: "abc123" },
+  },
+];
+
+const routes = [
+  {
+    path: "*",
+    element: <TestComponent />,
+  },
+];
+
+describe("Tabpanel", () => {
+  it("should render and display children", async () => {
+    const router = createMemoryRouter(routes, { initialEntries });
+    render(<RouterProvider router={router} />);
+
+    await screen.findByText("Howdy!");
+    expect(screen.getByText("Howdy!")).toBeInTheDocument();
+  });
+
+  it("should render accessibility attributes", async () => {
+    const router = createMemoryRouter(routes, { initialEntries });
+    render(<RouterProvider router={router} />);
+
+    await screen.findByRole("tabpanel");
+    expect(screen.getByRole("tabpanel")).toBeInTheDocument();
+    expect(screen.getByRole("tabpanel")).toHaveAttribute(
+      "id",
+      "rrtPanel-abc123"
+    );
+    expect(screen.getByRole("tabpanel")).toHaveAttribute(
+      "aria-labelledby",
+      "rrtTab-abc123"
+    );
+    expect(screen.getByRole("tabpanel")).toHaveAttribute("tabindex", "0");
+  });
+
+  it("should throw an error if not wrapped in context", async () => {
+    const consoleSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    expect(() => render(<Tabpanel />)).toThrow(
+      "Tabpanel must be wrapped in a RoutingTabs component"
+    );
+    consoleSpy.mockRestore();
+  });
+
+  it("should warn in the console if id is not found", async () => {
+    const consoleSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const router = createMemoryRouter(routes, { initialEntries: ["/"] });
+    render(<RouterProvider router={router} />);
+
+    const rrtIdError =
+      "Unable to get panel id from router state. This may affect the accessibility of this page. To fix this, make sure your Tabs and Tabpanel are inside a react-router-dom Router component.";
+
+    expect(consoleSpy).toHaveBeenCalledWith(rrtIdError);
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/components/Tabpanel/Tabpanel.tsx
+++ b/src/components/Tabpanel/Tabpanel.tsx
@@ -1,22 +1,15 @@
 import React, {
-  Children,
   ComponentProps,
   ForwardedRef,
   PropsWithChildren,
-  ReactNode,
   forwardRef,
-  isValidElement,
-  useMemo,
 } from "react";
 import { useRoutingTabs } from "../../context";
 import { useLocation } from "react-router-dom";
 import { panelPrefix, tabPrefix } from "../../utils";
-import { useRouterError } from "../../utils/useRouterError";
 import { useContextError } from "../../utils/useContextError";
 
 export interface TabpanelProps extends ComponentProps<"div"> {}
-
-type ChildArray = Array<Exclude<ReactNode, boolean | null | undefined>>;
 
 const componentName = "Tabpanel";
 

--- a/src/components/Tabpanel/Tabpanel.tsx
+++ b/src/components/Tabpanel/Tabpanel.tsx
@@ -1,0 +1,70 @@
+import React, {
+  Children,
+  ComponentProps,
+  ForwardedRef,
+  ReactNode,
+  forwardRef,
+  isValidElement,
+  useMemo,
+} from "react";
+import { useRoutingTabs } from "../../context";
+import { useLocation } from "react-router-dom";
+import { panelPrefix, tabPrefix } from "../../utils";
+
+export interface TabpanelProps extends ComponentProps<"div"> {
+  children: ReactNode;
+}
+
+type ChildArray = Array<Exclude<ReactNode, boolean | null | undefined>>;
+
+export const Tabpanel = forwardRef(
+  (
+    { children, ...props }: TabpanelProps,
+    outsideTabPanelRef?: ForwardedRef<HTMLDivElement>
+  ) => {
+    const routingTabContext = useRoutingTabs();
+    const tabContextError =
+      "Tabpanels must be wrapped in a RoutingTabs component";
+    if (!routingTabContext) {
+      console.error(tabContextError);
+      throw new Error(tabContextError);
+    }
+
+    const {
+      state: { rrtId },
+    } = useLocation();
+
+    // If there are no focusable children, the tabindex should be 0
+    const hasFocusableChild = useMemo(() => {
+      const findFocusableChild = (
+        childArray: ChildArray
+      ): ReactNode | undefined =>
+        childArray.find((child) => {
+          if (isValidElement(child)) {
+            if ("focus" in child) {
+              return true;
+            } else if ("children" in child) {
+              const grandchildren = Children.toArray(child.children);
+              return findFocusableChild(grandchildren);
+            }
+          }
+          return false;
+        });
+      const iterableChildren = Children.toArray(children);
+      return !!findFocusableChild(iterableChildren);
+    }, [children]);
+
+    return (
+      <div
+        aria-labelledby={tabPrefix + rrtId}
+        id={panelPrefix + rrtId}
+        ref={outsideTabPanelRef}
+        role="tabpanel"
+        tabIndex={hasFocusableChild ? -1 : 0}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  }
+);

--- a/src/components/Tabpanel/Tabpanel.tsx
+++ b/src/components/Tabpanel/Tabpanel.tsx
@@ -27,12 +27,9 @@ export const Tabpanel = forwardRef(
   ) => {
     const routingTabContext = useRoutingTabs();
     useContextError(componentName, routingTabContext);
-    useRouterError(componentName);
 
     const location = useLocation();
-
     const rrtId = location?.state?.rrtId;
-
     if (!rrtId) {
       // Don't crash, but make this known
       console.warn(
@@ -40,33 +37,13 @@ export const Tabpanel = forwardRef(
       );
     }
 
-    // If there are no focusable children, the tabindex should be 0
-    const hasFocusableChild = useMemo(() => {
-      const findFocusableChild = (
-        childArray: ChildArray
-      ): ReactNode | undefined =>
-        childArray.find((child) => {
-          if (isValidElement(child)) {
-            if ("focus" in child) {
-              return true;
-            } else if ("children" in child) {
-              const grandchildren = Children.toArray(child.children);
-              return findFocusableChild(grandchildren);
-            }
-          }
-          return false;
-        });
-      const iterableChildren = Children.toArray(children);
-      return !!findFocusableChild(iterableChildren);
-    }, [children]);
-
     return (
       <div
         aria-labelledby={tabPrefix + rrtId}
         id={panelPrefix + rrtId}
         ref={outsideTabPanelRef}
         role="tabpanel"
-        tabIndex={hasFocusableChild ? -1 : 0}
+        tabIndex={0}
         {...props}
       >
         {children}

--- a/src/components/Tabpanel/index.ts
+++ b/src/components/Tabpanel/index.ts
@@ -1,0 +1,1 @@
+export * from "./Tabpanel";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,2 +1,4 @@
 export * from "./Tablist";
 export * from "./Tabs";
+export * from "./Tabpanel";
+export * from "./TabPanelWindow";

--- a/src/context/RoutingTabContext.tsx
+++ b/src/context/RoutingTabContext.tsx
@@ -92,7 +92,12 @@ export const RoutingTabs = <T,>(
         (childTab) => childTab.id === id
       );
       const newRouteIndex = foundTabIndex > -1 ? foundTabIndex : 0;
-      navigate(getNewLocation(tabRoutes[newRouteIndex]), { replace });
+      navigate(getNewLocation(tabRoutes[newRouteIndex]), {
+        replace,
+        state: {
+          rrtId: id,
+        },
+      });
     },
     [childTabs, getNewLocation, navigate]
   );

--- a/src/stories/Tabpanel.stories.tsx
+++ b/src/stories/Tabpanel.stories.tsx
@@ -3,7 +3,6 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import { Tabpanel } from "../components";
 import { RoutingTabs } from "../context";
-import { Route, Routes } from "react-router-dom";
 
 const meta = {
   title: "Tabpanel",

--- a/src/stories/Tabpanel.stories.tsx
+++ b/src/stories/Tabpanel.stories.tsx
@@ -27,7 +27,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   render: () => (
-    <Tabpanel>
+    <Tabpanel style={{ fontFamily: "Arial, sans-serif" }}>
       <h1>Sample tab panel</h1>
       <p>The appropriate tab will route to this</p>
       <p>See devtools for additional accessibility attributes</p>

--- a/src/stories/Tabpanel.stories.tsx
+++ b/src/stories/Tabpanel.stories.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { Tab, Tabpanel } from "../components";
+import { Tabpanel } from "../components";
 import { RoutingTabs } from "../context";
+import { Route, Routes } from "react-router-dom";
 
 const meta = {
   title: "Tabpanel",
@@ -14,7 +15,9 @@ const meta = {
   decorators: [
     (Story) => (
       <RoutingTabs>
-        <Story />
+        <Routes>
+          <Route path="/" element={<Story />} />
+        </Routes>
       </RoutingTabs>
     ),
   ],

--- a/src/stories/Tabpanel.stories.tsx
+++ b/src/stories/Tabpanel.stories.tsx
@@ -15,9 +15,7 @@ const meta = {
   decorators: [
     (Story) => (
       <RoutingTabs>
-        <Routes>
-          <Route path="/" element={<Story />} />
-        </Routes>
+        <Story />
       </RoutingTabs>
     ),
   ],

--- a/src/stories/Tabpanel.stories.tsx
+++ b/src/stories/Tabpanel.stories.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Tab, Tabpanel } from "../components";
+import { RoutingTabs } from "../context";
+
+const meta = {
+  title: "Tabpanel",
+  component: Tabpanel,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <RoutingTabs>
+        <Story />
+      </RoutingTabs>
+    ),
+  ],
+} satisfies Meta<typeof Tabpanel>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <Tabpanel>
+      <h1>Sample tab panel</h1>
+      <p>The appropriate tab will route to this</p>
+      <p>See devtools for additional accessibility attributes</p>
+    </Tabpanel>
+  ),
+};

--- a/src/utils/useContextError.ts
+++ b/src/utils/useContextError.ts
@@ -1,0 +1,12 @@
+import { RoutingTabContextValue } from "../context";
+
+export const useContextError = <T>(
+  component: String,
+  routingTabContext: RoutingTabContextValue<T>
+): void => {
+  if (!routingTabContext) {
+    const tabContextError = `${component} must be wrapped in a RoutingTabs component`;
+    console.error(tabContextError);
+    throw new Error(tabContextError);
+  }
+};

--- a/src/utils/useRouterError.ts
+++ b/src/utils/useRouterError.ts
@@ -1,0 +1,11 @@
+import { useInRouterContext } from "react-router-dom";
+
+export const useRouterError = (component: string) => {
+  const isInRouter = useInRouterContext();
+
+  if (!isInRouter) {
+    // Don't crash, but make this known
+    const rrdError = `${component} is intended to be used within a react-router-dom router.\nYour application may still work, but may be missing key accessibility features.`;
+    console.error(rrdError);
+  }
+};


### PR DESCRIPTION
# Pull Request :white_check_mark:

## react-routing-tabs

> [!WARNING]
> I'm a stickler for documentation. If this is not filled out, the PR will be rejected! :no_entry:

Closes #7 

### Description
Creates a Tabpanel component that wraps the content for each tabpanel and renders accessibility attributes in the DOM.

#### New features

1. Tabpanel component

#### Fixes/other changes

1. Adds the ID to a tab's target route in state for access by the tabpanel

### Testing instructions

View Tabpanel in Storybook for a sample demonstration.

### Screenshots

![image](https://github.com/dLars99/react-routing-tabs/assets/54251395/2766235d-8d60-4907-bc4c-d8c60506254f)

### Documentation

- [x] All variables and files have clear, intuitive names
- [x] Anonymous functions (including useEffects) and confusing code have clear, concise comments
- [x] Storybook documentation references all changes
- [x] Unit tests cover all changes
- [x] No unintentional console messages are added
