### PR TITLE
fix(build): fix name of types file on build

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -35,7 +35,7 @@ export default [
   },
   {
     input: "src/index.ts",
-    output: [{ file: "dist/types.d.ts", format: "es" }],
+    output: [{ file: "dist/index.d.ts", format: "es" }],
     plugins: [dts.default()],
     external: [/\.css$/],
   },


### PR DESCRIPTION
# Pull Request :white_check_mark:

## react-routing-tabs

> [!WARNING]
> I'm a stickler for documentation. If this is not filled out, the PR will be rejected! :no_entry:

Closes #

### Description

Addresses an absolutely bone-headed mistake in the rollup config where the types declaration file name differed between package.json and rollup.config.