### PR TITLE
fix(tab): make property names consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ Manually-configured Tab components.
 (
   <RoutingTabs>
     <TabList>
-      <Tab label="Tab 1" link="tab-1" />
+      <Tab name="Tab 1" link="tab-1" />
 
-      <Tab label="Tab 2" link="tab-2" />
+      <Tab name="Tab 2" link="tab-2" />
     </TabList>
 
     <TabPanelWindow />
@@ -211,11 +211,11 @@ Clicking a tab routes to the correct location and, with a properly configured `T
 > `isNav?`: boolean
 > - Is this part of a true nav component?
 >
-> `label`: string
+> `name`: string
 > - Display text for the tab
 >
 > `link`?: string
-> - Destination link for the tab. If not provided, the tab will use a slug from the label
+> - Destination link for the tab. If not provided, the tab will use a slug from the name
 
 ----
 ### TabpanelWindow

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ Manually-configured Tab components.
 (
   <RoutingTabs>
     <TabList>
-      <Tab name="Tab 1" link="tab-1" />
+      <Tab name="Tab 1" route="tab-1" />
 
-      <Tab name="Tab 2" link="tab-2" />
+      <Tab name="Tab 2" route="tab-2" />
     </TabList>
 
     <TabPanelWindow />
@@ -104,7 +104,7 @@ Ideal for using tabs with minimal configuration with data from an external sourc
 ```
 
 ### Tabpanels
-Wherever your tabpanel is displayed for each link, wrap it in a TabPanel component. When rendered, this will wrap your content with all needed attributes to complete accessibility for your tabs.
+Wherever your tabpanel is displayed for each route, wrap it in a TabPanel component. When rendered, this will wrap your content with all needed attributes to complete accessibility for your tabs.
 
 ```tsx
 // Example route from a react-router-dom config
@@ -214,8 +214,8 @@ Clicking a tab routes to the correct location and, with a properly configured `T
 > `name`: string
 > - Display text for the tab
 >
-> `link`?: string
-> - Destination link for the tab. If not provided, the tab will use a slug from the name
+> `route`?: string
+> - Destination route for the tab. If not provided, the tab will use a slug from the name
 
 ----
 ### TabpanelWindow

--- a/src/components/Tablist/AutoGeneratedTabs/ConfigTabs.tsx
+++ b/src/components/Tablist/AutoGeneratedTabs/ConfigTabs.tsx
@@ -13,7 +13,7 @@ export const ConfigTabs = () => {
     ? config.map((configItem) => (
         <Tab
           key={configItem.route}
-          label={configItem.name}
+          name={configItem.name}
           link={configItem.route}
         />
       ))

--- a/src/components/Tablist/AutoGeneratedTabs/ConfigTabs.tsx
+++ b/src/components/Tablist/AutoGeneratedTabs/ConfigTabs.tsx
@@ -14,7 +14,7 @@ export const ConfigTabs = () => {
         <Tab
           key={configItem.route}
           name={configItem.name}
-          link={configItem.route}
+          route={configItem.route}
         />
       ))
     : null;

--- a/src/components/Tablist/AutoGeneratedTabs/DataTabs.tsx
+++ b/src/components/Tablist/AutoGeneratedTabs/DataTabs.tsx
@@ -24,7 +24,7 @@ export const DataTabs = <T,>() => {
     ? data.map((data, index) => (
         <Tab
           key={tabRoutes[index]}
-          label={dataIsPrimitive ? String(data) : String(data[tabLabelKey])}
+          name={dataIsPrimitive ? String(data) : String(data[tabLabelKey])}
           link={tabRoutes[index]}
         />
       ))

--- a/src/components/Tablist/AutoGeneratedTabs/DataTabs.tsx
+++ b/src/components/Tablist/AutoGeneratedTabs/DataTabs.tsx
@@ -25,7 +25,7 @@ export const DataTabs = <T,>() => {
         <Tab
           key={tabRoutes[index]}
           name={dataIsPrimitive ? String(data) : String(data[tabLabelKey])}
-          link={tabRoutes[index]}
+          route={tabRoutes[index]}
         />
       ))
     : null;

--- a/src/components/Tabs/AnchorTab.tsx
+++ b/src/components/Tabs/AnchorTab.tsx
@@ -10,7 +10,7 @@ export const AnchorTab = ({
   disabled = false,
   isNav = false,
   isSelected,
-  label,
+  name,
   link = ".",
   onClick,
   tabId,
@@ -33,7 +33,7 @@ export const AnchorTab = ({
       tabIndex={isSelected ? 0 : -1}
       to={disabled ? "" : parsedLink}
     >
-      {children ?? label}
+      {children ?? name}
     </NavLink>
   ) : (
     <Link
@@ -47,7 +47,7 @@ export const AnchorTab = ({
       tabIndex={isSelected ? 0 : -1}
       to={disabled ? "." : parsedLink}
     >
-      {children ?? label}
+      {children ?? name}
     </Link>
   );
 };

--- a/src/components/Tabs/AnchorTab.tsx
+++ b/src/components/Tabs/AnchorTab.tsx
@@ -11,7 +11,7 @@ export const AnchorTab = ({
   isNav = false,
   isSelected,
   name,
-  link = ".",
+  route = ".",
   onClick,
   tabId,
 }: AnchorTabProps) => {
@@ -19,7 +19,7 @@ export const AnchorTab = ({
   const routingTabContext = useRoutingTabs();
   if (!routingTabContext) return null;
   const { useHashRouting } = routingTabContext;
-  const parsedLink = useHashRouting ? "#" + link : link;
+  const parsedLink = useHashRouting ? "#" + route : route;
 
   return isNav ? (
     <NavLink

--- a/src/components/Tabs/Tab.test.tsx
+++ b/src/components/Tabs/Tab.test.tsx
@@ -11,14 +11,14 @@ enableFetchMocks();
 
 const FullTestComponent = ({
   children,
-  link,
+  route,
 }: {
   children?: ReactNode;
-  link?: string;
+  route?: string;
 }) => (
   <RoutingTabs>
     <TabList>
-      <Tab name="tab1" link={link}>
+      <Tab name="tab1" route={route}>
         {children}
       </Tab>
     </TabList>
@@ -28,7 +28,7 @@ const FullTestComponent = ({
 const defaultTestRoutes = [
   {
     path: "*",
-    element: <FullTestComponent link="tab2">Howdy!</FullTestComponent>,
+    element: <FullTestComponent route="tab2">Howdy!</FullTestComponent>,
   },
 ];
 
@@ -70,7 +70,7 @@ describe("Tab", () => {
     expect(screen.getByText("Howdy!")).toBeInTheDocument();
   });
 
-  it("should render a link when a link is provided", async () => {
+  it("should render a link when a route is provided", async () => {
     const router = createMemoryRouter(defaultTestRoutes, {
       initialEntries: ["/tab-0"],
     });
@@ -80,7 +80,7 @@ describe("Tab", () => {
     expect(screen.getByRole("tab")).toHaveAttribute("href");
   });
 
-  it("should render an empty anchor when no link is provided", async () => {
+  it("should render an empty anchor when no route is provided", async () => {
     const router = createMemoryRouter(linklessTestRoutes, {
       initialEntries: ["/tab-0"],
     });

--- a/src/components/Tabs/Tab.test.tsx
+++ b/src/components/Tabs/Tab.test.tsx
@@ -18,7 +18,7 @@ const FullTestComponent = ({
 }) => (
   <RoutingTabs>
     <TabList>
-      <Tab label="tab1" link={link}>
+      <Tab name="tab1" link={link}>
         {children}
       </Tab>
     </TabList>
@@ -44,7 +44,7 @@ describe("Tab", () => {
     const consoleSpy = jest
       .spyOn(console, "error")
       .mockImplementation(() => {});
-    expect(() => render(<Tab label="Howdy!" tabIndex={0} />)).toThrow(
+    expect(() => render(<Tab name="Howdy!" tabIndex={0} />)).toThrow(
       "Tab must be wrapped in a RoutingTabs component"
     );
     consoleSpy.mockRestore();
@@ -90,7 +90,7 @@ describe("Tab", () => {
     expect(screen.getByRole("tab")).toHaveAttribute("href", "/");
   });
 
-  it("should render the label when no children are provided", async () => {
+  it("should render the name when no children are provided", async () => {
     const router = createMemoryRouter(linklessTestRoutes, {
       initialEntries: ["/tab-0"],
     });

--- a/src/components/Tabs/Tab.tsx
+++ b/src/components/Tabs/Tab.tsx
@@ -3,14 +3,12 @@ import React, {
   MouseEvent,
   forwardRef,
   useCallback,
-  useId,
   useRef,
 } from "react";
 import "./styles/tab.css";
 import { AnchorTab } from "./AnchorTab";
 import { TabProps } from "./Tab.types";
 import classNames from "classnames";
-import { tabPrefix } from "../../utils";
 import { useRoutingTabs } from "../../context";
 
 /**

--- a/src/components/Tabs/Tab.types.ts
+++ b/src/components/Tabs/Tab.types.ts
@@ -16,7 +16,7 @@ export interface TabProps extends ComponentPropsWithRef<"a"> {
   /**
    * Display text for the tab
    */
-  label: string;
+  name: string;
   /**
    * Destination link for the tab
    */

--- a/src/components/Tabs/Tab.types.ts
+++ b/src/components/Tabs/Tab.types.ts
@@ -18,9 +18,9 @@ export interface TabProps extends ComponentPropsWithRef<"a"> {
    */
   name: string;
   /**
-   * Destination link for the tab
+   * Destination route for the tab
    */
-  link?: string;
+  route?: string;
 }
 
 export interface AnchorTabProps extends TabProps {

--- a/src/stories/RoutingsTabs.stories.tsx
+++ b/src/stories/RoutingsTabs.stories.tsx
@@ -21,9 +21,9 @@ export const Default: Story = {
   render: () => (
     <RoutingTabs>
       <TabList>
-        <Tab name="Tab 1" link="tab-1" />
+        <Tab name="Tab 1" route="tab-1" />
 
-        <Tab name="Tab 2" link="tab-2" />
+        <Tab name="Tab 2" route="tab-2" />
       </TabList>
 
       <TabPanelWindow />

--- a/src/stories/RoutingsTabs.stories.tsx
+++ b/src/stories/RoutingsTabs.stories.tsx
@@ -21,9 +21,9 @@ export const Default: Story = {
   render: () => (
     <RoutingTabs>
       <TabList>
-        <Tab label="Tab 1" link="tab-1" />
+        <Tab name="Tab 1" link="tab-1" />
 
-        <Tab label="Tab 2" link="tab-2" />
+        <Tab name="Tab 2" link="tab-2" />
       </TabList>
 
       <TabPanelWindow />

--- a/src/stories/Tab.stories.tsx
+++ b/src/stories/Tab.stories.tsx
@@ -27,7 +27,7 @@ type Story = StoryObj<typeof meta>;
 export const Link: Story = {
   args: {
     name: "Hi",
-    link: "tab-1",
+    route: "tab-1",
     isNav: false,
   },
   render: ({ ...args }) => <Tab {...args} />,
@@ -36,7 +36,7 @@ export const Link: Story = {
 export const NavLink: Story = {
   args: {
     name: "Hi",
-    link: "tab-1",
+    route: "tab-1",
     isNav: true,
   },
   render: ({ ...args }) => <Tab {...args} />,
@@ -45,7 +45,7 @@ export const NavLink: Story = {
 export const WithChildren: Story = {
   args: {
     name: "Hi",
-    link: "tab-1",
+    route: "tab-1",
   },
   render: ({ ...args }) => (
     <Tab {...args}>

--- a/src/stories/Tab.stories.tsx
+++ b/src/stories/Tab.stories.tsx
@@ -26,7 +26,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Link: Story = {
   args: {
-    label: "Hi",
+    name: "Hi",
     link: "tab-1",
     isNav: false,
   },
@@ -35,7 +35,7 @@ export const Link: Story = {
 
 export const NavLink: Story = {
   args: {
-    label: "Hi",
+    name: "Hi",
     link: "tab-1",
     isNav: true,
   },
@@ -44,7 +44,7 @@ export const NavLink: Story = {
 
 export const WithChildren: Story = {
   args: {
-    label: "Hi",
+    name: "Hi",
     link: "tab-1",
   },
   render: ({ ...args }) => (

--- a/src/stories/TabList.stories.tsx
+++ b/src/stories/TabList.stories.tsx
@@ -43,13 +43,13 @@ export const Horizontal: Story = {
   },
   render: (args) => (
     <TabList {...args}>
-      <Tab name="Thing 1" link="tab-1">
+      <Tab name="Thing 1" route="tab-1">
         Thing 1
       </Tab>
-      <Tab name="Thing 2" link="tab-2">
+      <Tab name="Thing 2" route="tab-2">
         Thing 2
       </Tab>
-      <Tab name="Thing 3" link="tab-3">
+      <Tab name="Thing 3" route="tab-3">
         Thing 3
       </Tab>
     </TabList>
@@ -62,13 +62,13 @@ export const Vertical: Story = {
   },
   render: (args) => (
     <TabList {...args}>
-      <Tab name="Thing 1" link="tab-1">
+      <Tab name="Thing 1" route="tab-1">
         Thing 1
       </Tab>
-      <Tab name="Thing 2" link="tab-2">
+      <Tab name="Thing 2" route="tab-2">
         Thing 2
       </Tab>
-      <Tab name="Thing 3" link="tab-3">
+      <Tab name="Thing 3" route="tab-3">
         Thing 3
       </Tab>
     </TabList>

--- a/src/stories/TabList.stories.tsx
+++ b/src/stories/TabList.stories.tsx
@@ -43,13 +43,13 @@ export const Horizontal: Story = {
   },
   render: (args) => (
     <TabList {...args}>
-      <Tab label="Thing 1" link="tab-1">
+      <Tab name="Thing 1" link="tab-1">
         Thing 1
       </Tab>
-      <Tab label="Thing 2" link="tab-2">
+      <Tab name="Thing 2" link="tab-2">
         Thing 2
       </Tab>
-      <Tab label="Thing 3" link="tab-3">
+      <Tab name="Thing 3" link="tab-3">
         Thing 3
       </Tab>
     </TabList>
@@ -62,13 +62,13 @@ export const Vertical: Story = {
   },
   render: (args) => (
     <TabList {...args}>
-      <Tab label="Thing 1" link="tab-1">
+      <Tab name="Thing 1" link="tab-1">
         Thing 1
       </Tab>
-      <Tab label="Thing 2" link="tab-2">
+      <Tab name="Thing 2" link="tab-2">
         Thing 2
       </Tab>
-      <Tab label="Thing 3" link="tab-3">
+      <Tab name="Thing 3" link="tab-3">
         Thing 3
       </Tab>
     </TabList>


### PR DESCRIPTION
# Pull Request :white_check_mark:

## react-routing-tabs

> [!WARNING]
> I'm a stickler for documentation. If this is not filled out, the PR will be rejected! :no_entry:

Closes #27 

### Description

Makes property names for tabs consistent across all implementation methods.

#### Fixes/other changes

1. Replaces `link` with `route` and `label` with `name` within Tabs

### Testing instructions

Test all name rendering for all three options: standard, config, and data.
Make sure all links navigate properly.

### Documentation

- [x] All variables and files have clear, intuitive names
- [x] Anonymous functions (including useEffects) and confusing code have clear, concise comments
- [x] Storybook documentation references all changes
- [x] Unit tests cover all changes
- [x] No unintentional console messages are added
