### PR TITLE
chore(release): 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2024-05-20
+
+### Changed
+
+- (**Breaking**) Make property names consistent for all tab types
+
 ## [0.1.3] - 2024-05-18
 
 ### Fixed


### PR DESCRIPTION
Release for 0.2.0.

Raised version as a minor due to breaking changes, despite being a bugfix.